### PR TITLE
autoload storage handlers

### DIFF
--- a/conf/config.rb
+++ b/conf/config.rb
@@ -29,6 +29,7 @@ Vines::Config.configure do
   #   private_storage false
   #   cross_domain_messages false
   #   storage 'fs' do
+  #     passwd_type 'sha256', 'some_optional_salt'
   #     dir 'data'
   #   end
   #   components 'tea'  => 'secr3t',

--- a/lib/vines.rb
+++ b/lib/vines.rb
@@ -56,7 +56,6 @@ end
 
 %w[
   base64
-  bcrypt
   digest/sha1
   eventmachine
   fiber

--- a/lib/vines.rb
+++ b/lib/vines.rb
@@ -55,7 +55,6 @@ module Vines
 end
 
 %w[
-  base64
   digest/sha1
   eventmachine
   fiber

--- a/lib/vines.rb
+++ b/lib/vines.rb
@@ -55,19 +55,13 @@ module Vines
 end
 
 %w[
-  active_record
   base64
   bcrypt
   digest/sha1
-  em-http
-  em-hiredis
   eventmachine
   fiber
   fileutils
-  http/parser
   logger
-  mongo
-  net/ldap
   nokogiri
   openssl
   resolv
@@ -110,13 +104,6 @@ end
   vines/stanza/pubsub/unsubscribe
 
   vines/storage
-  vines/storage/couchdb
-  vines/storage/ldap
-  vines/storage/local
-  vines/storage/mongodb
-  vines/storage/null
-  vines/storage/redis
-  vines/storage/sql
 
   vines/config
   vines/config/host

--- a/lib/vines/command/bcrypt.rb
+++ b/lib/vines/command/bcrypt.rb
@@ -5,6 +5,7 @@ module Vines
     class Bcrypt
       def run(opts)
         raise 'vines bcrypt <clear text>' unless opts[:args].size == 1
+        require 'bcrypt' unless defined?(BCrypt)
         puts BCrypt::Password.create(opts[:args].first)
       end
     end

--- a/lib/vines/storage.rb
+++ b/lib/vines/storage.rb
@@ -4,18 +4,32 @@ module Vines
   class Storage
     include Vines::Log
 
+    autoload :Null,    'vines/storage/null'
+    autoload :Ldap,    'vines/storage/ldap'
+    autoload :Local,   'vines/storage/local'
+    autoload :CouchDB, 'vines/storage/couchdb'
+    autoload :MongoDB, 'vines/storage/mongodb'
+    autoload :Sql,     'vines/storage/sql'
+    autoload :Redis,   'vines/storage/redis'
+
     attr_accessor :ldap
 
-    @@nicks = {}
+    @@nicks = {
+      'fs'      => 'Local',
+      'couchdb' => 'CouchDB',
+      'mongodb' => 'MongoDB',
+      'sql'     => 'Sql',
+      'redis'   => 'Redis',
+    }
 
     # Register a nickname that can be used in the config file to specify this
-    # storage implementation.
+    # storage implementation. (not really used anymore, see autoload)
     def self.register(name)
       @@nicks[name.to_sym] = self
     end
 
     def self.from_name(name, &block)
-      klass = @@nicks[name.to_sym]
+      klass = (const_get(@@nicks[name]) rescue nil) || @@nicks[name.to_sym]
       raise "#{name} storage class not found" unless klass
       klass.new(&block)
     end

--- a/lib/vines/storage/couchdb.rb
+++ b/lib/vines/storage/couchdb.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'em-http'
+
 module Vines
   class Storage
     class CouchDB < Storage

--- a/lib/vines/storage/ldap.rb
+++ b/lib/vines/storage/ldap.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'net/ldap'
+
 module Vines
   class Storage
 

--- a/lib/vines/storage/local.rb
+++ b/lib/vines/storage/local.rb
@@ -24,6 +24,10 @@ module Vines
         dir ? @dir = File.expand_path(dir) : @dir
       end
 
+      def passwd_type(type=nil, salt=nil);
+        type ? (@passwd_type, @passwd_salt = type, salt) : @passwd_type
+      end
+
       def find_user(jid)
         jid = JID.new(jid).bare.to_s
         file = absolute_path("user/#{jid}") unless jid.empty?

--- a/lib/vines/storage/mongodb.rb
+++ b/lib/vines/storage/mongodb.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'mongo'
+
 module Vines
   class Storage
     class MongoDB < Storage

--- a/lib/vines/storage/redis.rb
+++ b/lib/vines/storage/redis.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'em-hiredis'
+
 module Vines
   class Storage
     class Redis < Storage

--- a/lib/vines/storage/sql.rb
+++ b/lib/vines/storage/sql.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'active_record'
+
 module Vines
   class Storage
     class Sql < Storage

--- a/lib/vines/stream/client/auth.rb
+++ b/lib/vines/stream/client/auth.rb
@@ -35,7 +35,7 @@ module Vines
         # Authenticate s2s streams by comparing their domain to
         # their SSL certificate.
         def external_auth(stanza)
-          domain = Base64.decode64(stanza.text)
+          domain = stanza.text.unpack("m0")[0]
           cert = OpenSSL::X509::Certificate.new(stream.get_peer_cert) rescue nil
           if (!OpenSSL::SSL.verify_certificate_identity(cert, domain) rescue false)
             send_auth_fail(SaslErrors::NotAuthorized.new)
@@ -51,7 +51,7 @@ module Vines
         # authentication module in a separate thread to avoid blocking stanza
         # processing for other users.
         def plain_auth(stanza)
-          jid, node, password = Base64.decode64(stanza.text).split("\000")
+          jid, node, password = stanza.text.unpack("m0")[0].split("\000")
           jid = [node, stream.domain].join('@') if jid.nil? || jid.empty?
           log.info("Authenticating user: %s" % jid)
           @outstanding = true

--- a/lib/vines/stream/server/outbound/auth.rb
+++ b/lib/vines/stream/server/outbound/auth.rb
@@ -13,7 +13,7 @@ module Vines
 
           def node(node)
             raise StreamErrors::NotAuthorized unless external?(node)
-            authz = Base64.encode64(stream.domain).chomp
+            authz = [stream.domain].pack("m0")
             stream.write(%Q{<auth xmlns="#{NS}" mechanism="EXTERNAL">#{authz}</auth>})
             advance
           end


### PR DESCRIPTION
first of all thank you for this project, looks really nice! :)

here are two patches i came up while using/running vines for the first time.

i have the intention to run vines as a lightweight jabber server inside a vpn where fs storage is enough as a database. thats why i feel the need to autoload, or in my case, not load dependencies which are not needed. without my patches, vines makes you install all these gems even if your config won't use them.

the other part was adding optional salting and an alternative for bcrypt dependency to the local-storage password hashing method.
