### PR TITLE
Remove the last bits of VINES_ROOT

### DIFF
--- a/bin/vines
+++ b/bin/vines
@@ -80,7 +80,6 @@ def check_config(opts)
   end
 end
 
-VINES_ROOT = Dir.pwd
 opts = parse(ARGV)
 check_config(opts)
 command = Vines::Command.const_get(opts[:command].capitalize).new

--- a/lib/vines/config.rb
+++ b/lib/vines/config.rb
@@ -21,11 +21,16 @@ module Vines
     end
 
     def initialize(&block)
+      @certs = "conf/certs"
       @vhosts, @ports, @cluster = {}, {}, nil
       @null = Storage::Null.new
       @router = Router.new(self)
       instance_eval(&block)
       raise "must define at least one virtual host" if @vhosts.empty?
+    end
+
+    def certs value = nil
+      File.expand_path value ? @certs = value : @certs
     end
 
     def host(*names, &block)

--- a/lib/vines/stream.rb
+++ b/lib/vines/stream.rb
@@ -21,7 +21,7 @@ module Vines
       @remote_addr, @local_addr = addresses
       @user, @closed, @stanza_size = nil, false, 0
       @bucket = TokenBucket.new(100, 10)
-      @store = Store.new(File.join(VINES_ROOT, 'conf', 'certs'))
+      @store = Store.new(@config.certs)
       @nodes = EM::Queue.new
       process_node_queue
       create_parser


### PR DESCRIPTION
This adds a new top-level config directive called `certs`, which sets
the certificates directory (default is conf/certs). Since this is used
for initialization deep inside the cert store, it seems like it
belongs in config.
