### PR TITLE
improved scripts: test any file, run vines from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ $ script/bootstrap
 $ script/tests
 ```
 
+To run a single test file:
+
+```
+$ script/tests test/stream/parser_test.rb
+```
+
+To run the `vines` command straight from the source directory:
+
+```
+$ /path-to-src/script/vines init wonderland.lit
+```
+
 ## Contact
 
 * David Graham <david@negativecode.com>

--- a/script/tests
+++ b/script/tests
@@ -1,6 +1,13 @@
 #!/bin/sh
 
 set -e
-
-bundle exec rake test
-
+if [ "$1" != "" ]; then
+  if test -f "$1"; then
+    bundle exec rake test TEST=$1
+  else
+    echo "There is no test file $1"
+    exit
+  fi
+else
+  bundle exec rake test
+fi

--- a/script/vines
+++ b/script/vines
@@ -1,0 +1,15 @@
+#!/usr/bin/ruby
+
+#
+# You can use this script to run a development version of the `vines` command in any
+# directory, without installing the vines gem.
+#
+# Before this will work, run ./bootstrap to install the necessary gems in ".bundle".
+#
+# For extra fun, you can symlink this file to somewhere in your path. For example:
+#
+#     sudo ln -s /home/me/vines/script/vines /usr/local/bin
+#
+
+base_dir = File.expand_path('..', File.dirname(File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__))
+exec("BUNDLE_GEMFILE='#{base_dir}/Gemfile' bundle exec vines #{ARGV.join(' ')}")


### PR DESCRIPTION
This minor patch makes two changes:
- Allows you to run a test for just a single file. The tests are already fast, but when working in one area it is nice to have even faster tests.
- Allows you to run the vines command from the source repository from any other directory.
