### PR TITLE
Allow vines to work with nokogiri > 1.5.5

### DIFF
--- a/lib/vines/stream/parser.rb
+++ b/lib/vines/stream/parser.rb
@@ -66,12 +66,13 @@ module Vines
       def node(name, attrs=[], prefix=nil, uri=nil, ns=[])
         ignore = stream?(name, uri) ? [] : IGNORE
         doc = @node ? @node.document : Document.new
-        doc.create_element(name) do |node|
+        node = doc.create_element(name) do |node|
           attrs.each {|attr| node[attr.localname] = attr.value }
           ns.each {|prefix, uri| node.add_namespace(prefix, uri) unless ignore.include?(uri) }
-          node.namespace = node.add_namespace(prefix, uri) unless ignore.include?(uri)
           doc << node unless @node
         end
+        node.namespace = node.add_namespace(prefix, uri) unless ignore.include?(uri)
+        return node
       end
     end
   end


### PR DESCRIPTION
Since nokogiri v1.5.6, Nokogiri::XML::Document::create_element has this code:

```
if ns = elm.namespace_definitions.find { |n| n.prefix.nil? or n.prefix == '' }
  elm.namespace = ns
end
```

This new nokogiri behavior has the unfortunate consequence of overwriting the namespace set by vines for new nodes in parser.rb.

This pull request changes where the namespace is set by vines so that it does not get overwritten.

Without this change, vines does not work at all with nokogiri > 1.5.5, which is not so good since the current Gemfile will install 1.5.9 by default.
