### PR TITLE
Ruby 2.1.2 fixes

### DIFF
--- a/lib/vines/kit.rb
+++ b/lib/vines/kit.rb
@@ -5,7 +5,7 @@ module Vines
   module Kit
     # Create a hex-encoded, SHA-512 HMAC of the data, using the secret key.
     def self.hmac(key, data)
-      digest = OpenSSL::Digest::Digest.new("sha512")
+      digest = OpenSSL::Digest.respond_to?(:new) ? OpenSSL::Digest.new("sha512") : OpenSSL::Digest::Digest.new("sha512")
       OpenSSL::HMAC.hexdigest(digest, key, data)
     end
 

--- a/vines.gemspec
+++ b/vines.gemspec
@@ -16,15 +16,15 @@ Gem::Specification.new do |s|
   s.executables  = %w[vines]
   s.require_path = 'lib'
 
-  s.add_dependency 'bcrypt-ruby', '~> 3.0.1'
-  s.add_dependency 'em-hiredis', '~> 0.1.1'
-  s.add_dependency 'eventmachine', '~> 1.0.3'
-  s.add_dependency 'http_parser.rb', '~> 0.5.3'
-  s.add_dependency 'net-ldap', '~> 0.3.1'
-  s.add_dependency 'nokogiri', '~> 1.5.10'
+  s.add_dependency 'bcrypt-ruby', '~> 3.0', '>= 3.0.1'
+  s.add_dependency 'em-hiredis', '~> 0.1', '>= 0.1'
+  s.add_dependency 'eventmachine', '~> 1.0', '>= 1.0.3'
+  s.add_dependency 'http_parser.rb', '~> 0.5', '>= 0.5.3'
+  s.add_dependency 'net-ldap', '~> 0.3', '>= 0.3.1'
+  s.add_dependency 'nokogiri', '~> 1.5', '>= 1.5.10'
 
-  s.add_development_dependency 'minitest', '~> 5.0.5'
-  s.add_development_dependency 'rake', '~> 10.1.0'
+  s.add_development_dependency 'minitest', '~> 5.0', '>= 5.0.5'
+  s.add_development_dependency 'rake', '~> 10.1', '>= 10.1.0'
 
   s.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
Cleanup for Ruby 2.1.2. Everything seems to be working without errors or warnings EXCEPT #34, which is sporadic.
