### PR TITLE
prevent deprecation message in Ruby 2.1+ (works on 1.9.3+)

### DIFF
--- a/lib/vines/kit.rb
+++ b/lib/vines/kit.rb
@@ -5,7 +5,7 @@ module Vines
   module Kit
     # Create a hex-encoded, SHA-512 HMAC of the data, using the secret key.
     def self.hmac(key, data)
-      digest = OpenSSL::Digest::Digest.new("sha512")
+      digest = OpenSSL::Digest.new("sha512")
       OpenSSL::HMAC.hexdigest(digest, key, data)
     end
 


### PR DESCRIPTION
As discussed in #35, this is a much simpler and better way to prevent the deprecation message. May break on Ruby < 1.9.3.
